### PR TITLE
Add requests to scanner requirements

### DIFF
--- a/madrid-tracker/scanner/requirements.txt
+++ b/madrid-tracker/scanner/requirements.txt
@@ -1,3 +1,4 @@
 apify-client>=2.5.0
 psycopg2-binary==2.9.9
 python-dotenv==1.0.1
+requests==2.31.0


### PR DESCRIPTION
## Summary
- Adds `requests` back to scanner requirements — needed for Slack webhook notifications

## Test plan
- [ ] Re-run workflow manually from Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)